### PR TITLE
fix share button function

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,8 @@
-const shareBtn = document.querySelector(".fa-share-square");
+const shareBtn = document.querySelectorAll(".fa-share-square");
 
-shareBtn.addEventListener("click", () => {
-  alert("https://rmk-creative.github.io/bootstrap-cookbook/");
+shareBtn.forEach((elem) => {
+  elem.addEventListener("click", () => {
+    console.log("clicked");
+    alert("https://rmk-creative.github.io/bootstrap-cookbook/");
+  });
 });


### PR DESCRIPTION
Share btn was only working on first card. Updated the function to loop through all elements with shared class name in order for the event handler to work correctly.